### PR TITLE
Composite primary Improvments

### DIFF
--- a/api.php
+++ b/api.php
@@ -1329,8 +1329,7 @@ class PHP_CRUD_API {
     protected function processKeyParameter($key,$tables,$database) {
         if ($key===false) return false;
         $fields = $this->findPrimaryKeys($tables[0],$database);
-        if (count($fields)!=1) return array_merge(array(explode(',',$key)), $fields);
-        return array(explode(',',$key),$fields[0]);
+        return array_merge(array(explode(',',$key)), $fields);
     }
 
     protected function processOrderingsParameter($orderings) {


### PR DESCRIPTION
Adicionado melhoria para resolver a limitação de chave primaria composta do mevdschee/php-crud-api utilizando hifen na separação das chaves primarias em sequencia. Ex. de utilização: /api.php/category_description/88-1,88-2,88-3