### PR TITLE
feat: habilitando cors

### DIFF
--- a/api.php
+++ b/api.php
@@ -1297,7 +1297,7 @@ class PHP_CRUD_API {
 
     protected function headersCommand($parameters) {
         $headers = array();
-        $headers[]='Access-Control-Allow-Headers: Content-Type, X-XSRF-TOKEN';
+        $headers[]='Access-Control-Allow-Headers: Content-Type, X-XSRF-TOKEN, key';
         $headers[]='Access-Control-Allow-Methods: OPTIONS, GET, PUT, POST, DELETE, PATCH';
         $headers[]='Access-Control-Allow-Credentials: true';
         $headers[]='Access-Control-Max-Age: 1728000';

--- a/config_api.php
+++ b/config_api.php
@@ -114,13 +114,13 @@ foreach ($headers as $name => $value) {
   }
 }
 
-if (isset($key) && ctype_alnum($key)) {
+if (isset($key) && ctype_alnum($key) || $_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
   $conn = Database::connection();
   $sql = $conn->prepare("SELECT api_id FROM `" . DB_PREFIX . "api` WHERE `key` = :key AND `status` = '1'");
   $sql->bindParam(':key', $key, PDO::PARAM_STR);
   $sql->execute();
   $api_info = $sql->fetch(PDO::FETCH_OBJ);
-  if (isset($api_info->api_id) && ctype_digit($api_info->api_id)) {
+  if (isset($api_info->api_id) && ctype_digit($api_info->api_id) || $_SERVER['REQUEST_METHOD'] == 'OPTIONS') {
     if (RESTRICT_IP) {
       $sql = $conn->prepare("SELECT ip FROM `" . DB_PREFIX . "api_ip` WHERE `api_id` = :api_id AND `ip` = :ip");
       $sql->bindParam(':api_id', $api_info->api_id, PDO::PARAM_INT);


### PR DESCRIPTION
Deparei com a necessidade de um SPA acessar a api do Opencart.
Eu vi que a bibilioteca PHP-CRUD-API tem suporte a CORS, porém o arquivo config_api.php que faz a autenticação via parâmetro "key", bloqueando assim qualquer chamada de CORS (Cross-origin-resource-sharing).

Solução: adicionei o parâmetro de header no parâmetro 'Access-Control-Allow-Headers'.
Habilitei o tráfeto de comando `Options` para a api PHP-CRUD-API possa validar se o CORS está habilitado.